### PR TITLE
chore: add dark theme CSS

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,18 @@
       display: block;
       margin: 100px auto;
     }
+    
+    /* Darker colours for dark mode */
+    @media (prefers-color-scheme: dark) {
+      body {
+        color: #eaeaea;
+        background-color: #212121;
+      }
+      
+      a {
+        color: cyan;
+      }
+    }
 
   </style>
 


### PR DESCRIPTION
Dark theme CSS overrides are now available in Chrome/Safari, etc. This adds a custom style rule for Browsers with dark mode enabled.

See https://webkit.org/blog/8840/dark-mode-support-in-webkit/ for more information.